### PR TITLE
Fix Imports and Missing header file field

### DIFF
--- a/RSDK/Release/PayPalRetailSDK.framework/Headers/PayPalRetailSDK.h
+++ b/RSDK/Release/PayPalRetailSDK.framework/Headers/PayPalRetailSDK.h
@@ -10,6 +10,7 @@
 #import <UIKit/UIKit.h>
 #import "PayPalRetailSDKTypeDefs.h"
 #import "PayPalRetailSDKImports.h"
+#import "PPInstrumentationConstants.h"
 #import "PPHRetailMerchant.h"
 #import "PPRetailError.h"
 #import <PPRetailInstrumentInterface/PPRetailInstrumentationDelegate.h>

--- a/frameworks/PPHR_BLE.framework/Versions/A/Headers/RUAFileVersionInfo.h
+++ b/frameworks/PPHR_BLE.framework/Versions/A/Headers/RUAFileVersionInfo.h
@@ -10,7 +10,7 @@
 #ifdef RUA_MFI
 #import <LandiSDK_MFI/LDTmsFileVersionInfo.h>
 #else
-#import <LandiSDK_BLE/LDTmsFileVersionInfo.h>
+#import <PPHSDK_BLE/LDTmsFileVersionInfo.h>
 #endif
 
 @interface RUAFileVersionInfo : NSObject

--- a/frameworks/PPHR_BLE.framework/Versions/A/Headers/RUAFileVersionInfo.h
+++ b/frameworks/PPHR_BLE.framework/Versions/A/Headers/RUAFileVersionInfo.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 #ifdef RUA_MFI
-#import <LandiSDK_MFI/LDTmsFileVersionInfo.h>
+#import <PPHSDK_MFI/LDTmsFileVersionInfo.h>
 #else
 #import <PPHSDK_BLE/LDTmsFileVersionInfo.h>
 #endif


### PR DESCRIPTION
This adds a missing import in the header file, as well as corrects some imports from within the frameworks.

Fixes bug [#290](https://github.com/paypal/paypal-here-sdk-ios-distribution/issues/290)